### PR TITLE
Add parentheses to fix bug related to operator precedence

### DIFF
--- a/apps/Kernel/TimerDriverP.nc
+++ b/apps/Kernel/TimerDriverP.nc
@@ -62,7 +62,7 @@ implementation
 
     void enqueue_cb(uint16_t idx)
     {
-        if ((cb_widx + 1) & (CBQUEUESIZE-1) == cb_ridx)
+        if (((cb_widx + 1) & (CBQUEUESIZE-1)) == cb_ridx)
             return; //drop
         callback_queue[cb_widx] = timer_buffer[idx].cb;
         cb_widx = (cb_widx+1) & (CBQUEUESIZE-1);


### PR DESCRIPTION
The Timer Driver in the kernel statically allocates a queue of callbacks, and drops callbacks when the queue is full. However, the kernel does not correctly check if the queue is full. As a result, it incorrectly drops callbacks when there is in fact space in the queue.

The result of this bug is two-fold. First, a callback that should occur may be erroneously ignored. Second, the memory associated with the context of the callback is leaked. This "normally" happens when the queue is full, but as a result of this issue, it can happen otherwise as well.

The cause of this bug is that in nesC, the equality (==) operator takes precedence over the bitwise AND (&) operator (whereas in C, both have equal precedence).

This pull request adds parentheses to account for this operator precedence and fix the bug.
