### PR TITLE
Fixed timer bug (again), with proper handling of Counter overflow signal

### DIFF
--- a/tos/chips/cortex/m4/sam4/l/ast/HplSam4lASTP.nc
+++ b/tos/chips/cortex/m4/sam4/l/ast/HplSam4lASTP.nc
@@ -197,8 +197,12 @@ implementation
 	     * than or equal to cv. This is catastrophic, so we manually bump forward
 	     * the alarm time in this situation
 	     */
-	    if (AST->cv >= val) val = AST->cv+1;
+	    if (AST->cv >= val && ((AST->cv - val) < 32)) {
+	        val = AST->cv + 1;
+	    }
 		AST->ar0 = val;
+		
+		while(AST->sr.bits.busy == 1); // Wait for register to sync
 	}
 
 	async command uint32_t HplSam4lAST.getAlarm()


### PR DESCRIPTION
Michael:
I tried out your suggestion. It turns out that the register properly syncs even when the AST is disabled. So I have added the spin loop in setAlarm to block until transfer of the alarm value finishes.

Now that we have some more certainty in how the alarm value is set, I went ahead and implemented proper handling of the overflow signal.

I also followed your suggestion and set the counter value, to account for the fact that it may "drift" forward even when the AST is disabled. Do you think we still need the if statement of line 200 of HplSam4lASTP? By the way, I modified that if statement so it handles overflow correctly. This probably isn't the bug that Gabe ran into, but it is a bug nonetheless.
